### PR TITLE
added nonumbers argument information

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 By running KristVanity without arguments, it will start searching for addresses on all threads without outputting to any files. The terms to look for will by default be taken from `terms.txt`.  
 
 You can use these arguments to configure this behaviour:
+* `--nonumbers` / `-n` Ignores addresses that contain numbers.
 * `--log` / `-l` Determines a log file to output to. Will create a new file if needed and won't replace existing file contents.
 * `--clean` / `-c` Will force KristVanity to only output address results, and this only in the format `address:password`. Useful for piping into a file.
 * `--threads` / `-t` The number of threads to use for mining addresses. Will default to the amount of cores on your system.


### PR DESCRIPTION
Added the nonumbers / -n arguments usage information as displayed in the --help command, because that was still missing in the readme.md